### PR TITLE
File Handling: Change permissions to octal

### DIFF
--- a/code/lesson24/open.asm
+++ b/code/lesson24/open.asm
@@ -14,7 +14,7 @@ global  _start
 
 _start:
 
-    mov     ecx, 0777           ; Create file from lesson 22
+    mov     ecx, 0777o          ; Create file from lesson 22
     mov     ebx, filename
     mov     eax, 8
     int     80h


### PR DESCRIPTION
If I run any code for the File Handling, I got the readme.txt file with these permissions: "-r----x--t", I research how to fix it and I discovered that it needs to be in octal mode, you are able to use the octal nomenclatures: 0777o or 0o0777. With this change I got these permissions: "-rwxr-xr-x", it is not the full 777 but at least I'm able to update the file.

Sources:
How do you create in python a file with permissions other users can write
https://stackoverflow.com/questions/36745577/how-do-you-create-in-python-a-file-with-permissions-other-users-can-write#comment93640008_36745577

3.4.1 Numeric Constants
https://www.nasm.us/doc/nasmdoc3.html
mov     ax,310q         ; octal
mov     ax,310o         ; octal again
mov     ax,0o310        ; octal yet again
mov     ax,0q310        ; octal yet again