### PR TITLE
Lesson 3: Null terminator vs. Newline comparison

### DIFF
--- a/code/lesson3/helloworld-len.asm
+++ b/code/lesson3/helloworld-len.asm
@@ -15,7 +15,7 @@ _start:
     mov     eax, ebx        ; move the address in EBX into EAX as well (Both now point to the same segment in memory)
     
 nextchar:
-    cmp     byte [eax], 0   ; compare the byte pointed to by EAX at this address against zero (Zero is an end of string delimiter)
+    cmp     byte [eax], 0Ah ; compare the byte pointed to by EAX at this address against 0Ah (0x0A is a newline)
     jz      finished        ; jump (if the zero flagged has been set) to the point in the code labeled 'finished'
     inc     eax             ; increment the address in EAX by one byte (if the zero flagged has NOT been set)
     jmp     nextchar        ; jump to the point in the code labeled 'loop'


### PR DESCRIPTION
If the program looks for a zero, it will stop at a _null terminator_. However, the "msg" ends with a _newline_ (hex 0x0A). In decimal, a newline is 10 instead of 0, but I believe it is more simple to compare the newline in hex (0x0A).