### PR TITLE
NUL terminate "msg" in lessons 3 & 4

### DIFF
--- a/code/lesson3/helloworld-len.asm
+++ b/code/lesson3/helloworld-len.asm
@@ -4,7 +4,7 @@
 ; Run with: ./helloworld-len
 
 SECTION .data
-msg     db      'Hello, brave new world!', 0Ah ; we can modify this now without having to update anywhere else in the program
+msg     db      'Hello, brave new world!', 0Ah, 0h ; we can modify this now without having to update anywhere else in the program
 
 SECTION .text
 global  _start

--- a/code/lesson4/helloworld-len.asm
+++ b/code/lesson4/helloworld-len.asm
@@ -4,7 +4,7 @@
 ; Run with: ./helloworld-len
 
 SECTION .data
-msg     db      'Hello, brave new world!', 0AH
+msg     db      'Hello, brave new world!', 0AH, 0h
 
 SECTION .text
 global  _start

--- a/docs/index.html
+++ b/docs/index.html
@@ -537,7 +537,7 @@
                             ; Run with: ./helloworld-len
 
                             SECTION .data
-                            msg     db      'Hello, brave new world!', 0Ah ; we can modify this now without having to update anywhere else in the program
+                            msg     db      'Hello, brave new world!', 0Ah, 0h ; we can modify this now without having to update anywhere else in the program
 
                             SECTION .text
                             global  _start
@@ -619,7 +619,7 @@
                             ; Run with: ./helloworld-len
 
                             SECTION .data
-                            msg     db      'Hello, brave new world!', 0Ah
+                            msg     db      'Hello, brave new world!', 0Ah, 0h
 
                             SECTION .text
                             global  _start


### PR DESCRIPTION
Terminate "msg" in lessons 3 and 4 with a NUL (0 byte) instead of relying on NUL padding inserted by the assembler to align things properly.