### PR TITLE
Fix read/ write typo lesson 9

### DIFF
--- a/code/lesson9/helloworld-input.asm
+++ b/code/lesson9/helloworld-input.asm
@@ -22,7 +22,7 @@ _start:
 
 	mov     edx, 255        ; number of bytes to read
 	mov     ecx, sinput     ; reserved space to store our input (known as a buffer)
-	mov     ebx, 0          ; write to the STDIN file
+	mov     ebx, 0          ; read from the STDIN file
 	mov     eax, 3          ; invoke SYS_READ (kernel opcode 3)
     int     80h
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1089,7 +1089,7 @@
                             <ul>
                                 <li> EDX will be loaded with the maximum length (in bytes) of the space in memory.</li>
                                 <li> ECX will be loaded with the address of our variable created in the .bss section.</li>
-                                <li> EBX will be loaded with the file we want to write to – in this case STDIN.</li>
+                                <li> EBX will be loaded with the file we want to read from – in this case STDIN.</li>
                             </ul>
                             As always the datatype and meaning of the arguments passed can be found in the function's definition.
                         </p>
@@ -1123,7 +1123,7 @@
 
                                 mov     edx, 255        ; number of bytes to read
                                 mov     ecx, sinput     ; reserved space to store our input (known as a buffer)
-                                mov     ebx, 0          ; write to the STDIN file
+                                mov     ebx, 0          ; read from the STDIN file
                                 mov     eax, 3          ; invoke SYS_READ (kernel opcode 3)
                                 int     80h
 


### PR DESCRIPTION
Hi. I've fixed what is a presumed doc/ comments typo in lesson 9, as we would want to read from `STDIN` and not write to it.

Thank you.