### PR TITLE
Fixed a typo in Lesson 9

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1089,7 +1089,7 @@
                             <ul>
                                 <li> EDX will be loaded with the maximum length (in bytes) of the space in memory.</li>
                                 <li> ECX will be loaded with the address of our variable created in the .bss section.</li>
-                                <li> EBX will be loaded with the file we want to write to – in this case STDIN.</li>
+                                <li> EBX will be loaded with the file we want to read from – in this case STDIN.</li>
                             </ul>
                             As always the datatype and meaning of the arguments passed can be found in the function's definition.
                         </p>


### PR DESCRIPTION
Line 1092, which is Lesson 9 of the page, had a small mistake, stating `EBX will be loaded with the file we want to write to – in this case STDIN.`
This is not the case, and is instead `... we want to ***read from***...`
This just fixes the issue, and hopefully clears up any misunderstandings stemming from it.