### PR TITLE
Revert "Lesson 16: Remove excessive register saving"

### DIFF
--- a/code/lesson16/functions.asm
+++ b/code/lesson16/functions.asm
@@ -4,6 +4,7 @@
 atoi:
     push    ebx             ; preserve ebx on the stack to be restored after function runs
     push    ecx             ; preserve ecx on the stack to be restored after function runs
+    push    edx             ; preserve edx on the stack to be restored after function runs
     push    esi             ; preserve esi on the stack to be restored after function runs
     mov     esi, eax        ; move pointer in eax into esi (our number to convert)
     mov     eax, 0          ; initialise eax with decimal value 0
@@ -32,6 +33,7 @@ atoi:
 
 .restore:
     pop     esi             ; restore esi from the value we pushed onto the stack at the start
+    pop     edx             ; restore edx from the value we pushed onto the stack at the start
     pop     ecx             ; restore ecx from the value we pushed onto the stack at the start
     pop     ebx             ; restore ebx from the value we pushed onto the stack at the start
     ret

--- a/docs/index.html
+++ b/docs/index.html
@@ -1679,6 +1679,7 @@
                                 atoi:
                                     push    ebx             ; preserve ebx on the stack to be restored after function runs
                                     push    ecx             ; preserve ecx on the stack to be restored after function runs
+                                    push    edx             ; preserve edx on the stack to be restored after function runs
                                     push    esi             ; preserve esi on the stack to be restored after function runs
                                     mov     esi, eax        ; move pointer in eax into esi (our number to convert)
                                     mov     eax, 0          ; initialise eax with decimal value 0
@@ -1707,6 +1708,7 @@
 
                                 .restore:
                                     pop     esi             ; restore esi from the value we pushed onto the stack at the start
+                                    pop     edx             ; restore edx from the value we pushed onto the stack at the start
                                     pop     ecx             ; restore ecx from the value we pushed onto the stack at the start
                                     pop     ebx             ; restore ebx from the value we pushed onto the stack at the start
                                     ret


### PR DESCRIPTION
Reverts DGivney/assemblytutorials#38

EDX's value is set by the DIV instruction (used to store the remainder)